### PR TITLE
feat: add configurable email tracking for commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,47 @@ Think of it as a **black box recorder for your dev work**: light, ambient, and s
 ### ⚡ Key Features
 - **Transparent logging**: Captures coding activity without interrupting your flow
 - **Git + AI context**: Merges commit history with assistant interactions
+- **Flexible email tracking**: Configure multiple email addresses to track commits from
 - **Human-friendly summaries**: Turn messy traces into readable narratives
 - **MCP-native**: Integrates with any client that speaks MCP
 - **Privacy-first**: You control what gets logged, stored, or shared
 
 
+
+---
+
+### ⚙️ Configuration
+
+Glin supports multiple ways to configure which email addresses to track commits from:
+
+#### 1. Environment Variable (Highest Priority)
+Set the `GLIN_TRACK_EMAILS` environment variable with a comma-separated list of emails:
+```bash
+export GLIN_TRACK_EMAILS="user1@example.com,user2@example.com,team@company.com"
+```
+
+#### 2. Configuration File
+Create a `glin.toml` file in one of these locations:
+- Current directory: `./glin.toml`
+- User config: `~/.config/glin/glin.toml`
+- User home: `~/.glin.toml`
+
+Example `glin.toml`:
+```toml
+# Glin Configuration
+# List of email addresses to track commits from
+track_emails = ["user1@example.com", "user2@example.com", "team@company.com"]
+```
+
+#### 3. Git Configuration (Fallback)
+If no explicit configuration is found, Glin falls back to your git configuration:
+- `git config user.email` (preferred)
+- `git config user.name` (if email not set)
+
+#### MCP Tools for Configuration
+Glin provides MCP tools to manage email configuration:
+- `get_tracked_email_config`: View current configuration
+- `configure_tracked_emails`: Set email addresses via environment variable or config file
 
 ---
 

--- a/glin/config.py
+++ b/glin/config.py
@@ -1,0 +1,167 @@
+"""Configuration management for Glin."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+def get_tracked_emails() -> list[str]:
+    """
+    Get the list of email addresses to track commits from.
+    
+    Priority order:
+    1. GLIN_TRACK_EMAILS environment variable (comma-separated)
+    2. glin.toml configuration file
+    3. Git user.email configuration
+    4. Git user.name configuration (as fallback)
+    
+    Returns:
+        List of email addresses/patterns to track. Empty list if none configured.
+    """
+    # 1. Check environment variable first
+    env_emails = os.getenv("GLIN_TRACK_EMAILS")
+    if env_emails:
+        return [email.strip() for email in env_emails.split(",") if email.strip()]
+    
+    # 2. Check for configuration file
+    config_emails = _get_config_file_emails()
+    if config_emails:
+        return config_emails
+    
+    # 3. Fallback to git configuration (current behavior)
+    git_pattern = _get_git_author_pattern()
+    if git_pattern:
+        return [git_pattern]
+    
+    return []
+
+
+def _get_config_file_emails() -> list[str]:
+    """
+    Read email configuration from glin.toml file.
+    
+    Returns:
+        List of emails from config file, or empty list if file doesn't exist or has no emails.
+    """
+    config_paths = [
+        Path.cwd() / "glin.toml",
+        Path.home() / ".config" / "glin" / "glin.toml",
+        Path.home() / ".glin.toml",
+    ]
+    
+    for config_path in config_paths:
+        if config_path.exists():
+            try:
+                # Simple TOML parsing for emails array
+                content = config_path.read_text()
+                emails = _parse_emails_from_toml(content)
+                if emails:
+                    return emails
+            except Exception:
+                # If config file is malformed, continue to next location
+                continue
+    
+    return []
+
+
+def _parse_emails_from_toml(content: str) -> list[str]:
+    """
+    Simple TOML parser for extracting emails array.
+    
+    Looks for: track_emails = ["email1", "email2", ...]
+    
+    Args:
+        content: TOML file content
+        
+    Returns:
+        List of emails found in the configuration
+    """
+    emails = []
+    lines = content.split('\n')
+    
+    for line in lines:
+        line = line.strip()
+        if line.startswith('track_emails'):
+            # Extract emails from array format
+            if '=' in line:
+                array_part = line.split('=', 1)[1].strip()
+                if array_part.startswith('[') and array_part.endswith(']'):
+                    # Remove brackets and split by comma
+                    items = array_part[1:-1].split(',')
+                    for item in items:
+                        item = item.strip().strip('"').strip("'")
+                        if item:
+                            emails.append(item)
+    
+    return emails
+
+
+def _get_git_author_pattern() -> Optional[str]:
+    """
+    Return the git-configured author pattern to filter commits.
+    Prefers user.email; falls back to user.name. Returns None if neither is set.
+    """
+    try:
+        email = subprocess.run(
+            ["git", "config", "--get", "user.email"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        email = ""
+
+    if email:
+        return email
+
+    try:
+        name = subprocess.run(
+            ["git", "config", "--get", "user.name"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        name = ""
+
+    return name or None
+
+
+def set_tracked_emails_env(emails: list[str]) -> None:
+    """
+    Set the GLIN_TRACK_EMAILS environment variable.
+    
+    Args:
+        emails: List of email addresses to track
+    """
+    os.environ["GLIN_TRACK_EMAILS"] = ",".join(emails)
+
+
+def create_config_file(emails: list[str], config_path: Optional[Path] = None) -> Path:
+    """
+    Create a glin.toml configuration file with the specified emails.
+    
+    Args:
+        emails: List of email addresses to track
+        config_path: Optional path for config file. Defaults to ./glin.toml
+        
+    Returns:
+        Path to the created configuration file
+    """
+    if config_path is None:
+        config_path = Path.cwd() / "glin.toml"
+    
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    # Create TOML content
+    emails_array = "[" + ", ".join(f'"{email}"' for email in emails) + "]"
+    content = f"""# Glin Configuration
+# List of email addresses to track commits from
+track_emails = {emails_array}
+"""
+    
+    config_path.write_text(content)
+    return config_path

--- a/glin/git_tools.py
+++ b/glin/git_tools.py
@@ -3,38 +3,20 @@ from __future__ import annotations
 import subprocess
 from typing import Optional
 
+from .config import get_tracked_emails, set_tracked_emails_env, create_config_file
 from .mcp_app import mcp
 
 
-def _get_git_author_pattern() -> Optional[str]:
+def _get_author_filters() -> list[str]:
     """
-    Return the git-configured author pattern to filter commits.
-    Prefers user.email; falls back to user.name. Returns None if neither is set.
+    Get the list of author patterns to filter commits by.
+    Uses the new configuration system that supports multiple emails.
+    
+    Returns:
+        List of author patterns (emails/names) to filter commits by.
+        Empty list if no configuration is found.
     """
-    try:
-        email = subprocess.run(
-            ["git", "config", "--get", "user.email"],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-    except subprocess.CalledProcessError:
-        email = ""
-
-    if email:
-        return email
-
-    try:
-        name = subprocess.run(
-            ["git", "config", "--get", "user.name"],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-    except subprocess.CalledProcessError:
-        name = ""
-
-    return name or None
+    return get_tracked_emails()
 
 
 def get_recent_commits(count: int = 10) -> list[dict]:
@@ -48,17 +30,22 @@ def get_recent_commits(count: int = 10) -> list[dict]:
         List of commit dictionaries with hash, author, date, and message
     """
     try:
-        # Format: hash|author|date|message
-        author = _get_git_author_pattern()
-        if not author:
-            return [{"error": "Git author not configured. Please set user.email or user.name"}]
+        # Get configured author filters
+        author_filters = _get_author_filters()
+        if not author_filters:
+            return [{"error": "No email addresses configured for tracking. Set GLIN_TRACK_EMAILS environment variable, create glin.toml, or configure git user.email"}]
+        
+        # Build git log command with multiple author filters
+        cmd = ["git", "log", f"-{count}"]
+        
+        # Add author filters - git log supports multiple --author flags (OR logic)
+        for author in author_filters:
+            cmd.extend([f"--author={author}"])
+        
+        cmd.append("--pretty=format:%H|%an|%ai|%s")
+        
         result = subprocess.run(
-            [
-                "git", "log",
-                f"-{count}",
-                f"--author={author}",
-                "--pretty=format:%H|%an|%ai|%s"
-            ],
+            cmd,
             capture_output=True,
             text=True,
             check=True
@@ -94,17 +81,22 @@ def get_commits_by_date(since: str, until: str = "now") -> list[dict]:
         List of commit dictionaries with hash, author, date, and message
     """
     try:
-        author = _get_git_author_pattern()
-        if not author:
-            return [{"error": "Git author not configured. Please set user.email or user.name"}]
+        # Get configured author filters
+        author_filters = _get_author_filters()
+        if not author_filters:
+            return [{"error": "No email addresses configured for tracking. Set GLIN_TRACK_EMAILS environment variable, create glin.toml, or configure git user.email"}]
+        
+        # Build git log command with multiple author filters
+        cmd = ["git", "log", f"--since={since}", f"--until={until}"]
+        
+        # Add author filters - git log supports multiple --author flags (OR logic)
+        for author in author_filters:
+            cmd.extend([f"--author={author}"])
+        
+        cmd.append("--pretty=format:%H|%an|%ai|%s")
+        
         result = subprocess.run(
-            [
-                "git", "log",
-                f"--since={since}",
-                f"--until={until}",
-                f"--author={author}",
-                "--pretty=format:%H|%an|%ai|%s"
-            ],
+            cmd,
             capture_output=True,
             text=True,
             check=True
@@ -128,6 +120,114 @@ def get_commits_by_date(since: str, until: str = "now") -> list[dict]:
         return [{"error": f"Failed to get commits: {str(e)}"}]
 
 
+def get_tracked_email_config() -> dict:
+    """
+    Get the current email tracking configuration.
+    
+    Returns:
+        Dictionary with current configuration details
+    """
+    emails = get_tracked_emails()
+    return {
+        "tracked_emails": emails,
+        "count": len(emails),
+        "source": _get_config_source()
+    }
+
+
+def configure_tracked_emails(emails: list[str], method: str = "env") -> dict:
+    """
+    Configure email addresses to track commits from.
+    
+    Args:
+        emails: List of email addresses to track
+        method: Configuration method - "env" for environment variable, "file" for config file
+        
+    Returns:
+        Dictionary with configuration result
+    """
+    try:
+        if method == "env":
+            set_tracked_emails_env(emails)
+            return {
+                "success": True,
+                "message": f"Set GLIN_TRACK_EMAILS environment variable with {len(emails)} emails",
+                "emails": emails,
+                "method": "environment_variable"
+            }
+        elif method == "file":
+            config_path = create_config_file(emails)
+            return {
+                "success": True,
+                "message": f"Created configuration file at {config_path} with {len(emails)} emails",
+                "emails": emails,
+                "method": "config_file",
+                "config_path": str(config_path)
+            }
+        else:
+            return {
+                "success": False,
+                "error": f"Unknown configuration method: {method}. Use 'env' or 'file'"
+            }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": f"Failed to configure emails: {str(e)}"
+        }
+
+
+def _get_config_source() -> str:
+    """
+    Determine the source of the current email configuration.
+    
+    Returns:
+        String describing the configuration source
+    """
+    import os
+    from pathlib import Path
+    
+    # Check environment variable
+    if os.getenv("GLIN_TRACK_EMAILS"):
+        return "environment_variable"
+    
+    # Check config files
+    config_paths = [
+        Path.cwd() / "glin.toml",
+        Path.home() / ".config" / "glin" / "glin.toml", 
+        Path.home() / ".glin.toml",
+    ]
+    
+    for config_path in config_paths:
+        if config_path.exists():
+            return f"config_file ({config_path})"
+    
+    # Check git config
+    try:
+        import subprocess
+        subprocess.run(
+            ["git", "config", "--get", "user.email"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return "git_user_email"
+    except subprocess.CalledProcessError:
+        pass
+    
+    try:
+        subprocess.run(
+            ["git", "config", "--get", "user.name"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return "git_user_name"
+    except subprocess.CalledProcessError:
+        pass
+    
+    return "none"
+
+
 
 # Register MCP tool wrappers preserving public names
 @mcp.tool(name="get_recent_commits")
@@ -138,3 +238,13 @@ def _tool_get_recent_commits(count: int = 10) -> list[dict]:  # pragma: no cover
 @mcp.tool(name="get_commits_by_date")
 def _tool_get_commits_by_date(since: str, until: str = "now") -> list[dict]:  # pragma: no cover
     return get_commits_by_date(since=since, until=until)
+
+
+@mcp.tool(name="get_tracked_email_config")
+def _tool_get_tracked_email_config() -> dict:  # pragma: no cover
+    return get_tracked_email_config()
+
+
+@mcp.tool(name="configure_tracked_emails")
+def _tool_configure_tracked_emails(emails: list[str], method: str = "env") -> dict:  # pragma: no cover
+    return configure_tracked_emails(emails=emails, method=method)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,248 @@
+"""Tests for configuration management."""
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from glin.config import (
+    get_tracked_emails,
+    set_tracked_emails_env,
+    create_config_file,
+    _get_config_file_emails,
+    _parse_emails_from_toml,
+    _get_git_author_pattern,
+)
+
+
+class TestGetTrackedEmails:
+    def test_env_variable_takes_priority(self, monkeypatch):
+        """Environment variable should take priority over other sources."""
+        monkeypatch.setenv("GLIN_TRACK_EMAILS", "env@example.com,env2@example.com")
+        
+        # Mock other sources to ensure they're not used
+        with patch('glin.config._get_config_file_emails', return_value=['file@example.com']):
+            with patch('glin.config._get_git_author_pattern', return_value='git@example.com'):
+                emails = get_tracked_emails()
+                assert emails == ["env@example.com", "env2@example.com"]
+
+    def test_config_file_fallback(self, monkeypatch):
+        """Config file should be used when env variable is not set."""
+        monkeypatch.delenv("GLIN_TRACK_EMAILS", raising=False)
+        
+        with patch('glin.config._get_config_file_emails', return_value=['file@example.com']):
+            with patch('glin.config._get_git_author_pattern', return_value='git@example.com'):
+                emails = get_tracked_emails()
+                assert emails == ["file@example.com"]
+
+    def test_git_config_fallback(self, monkeypatch):
+        """Git config should be used when env and config file are not available."""
+        monkeypatch.delenv("GLIN_TRACK_EMAILS", raising=False)
+        
+        with patch('glin.config._get_config_file_emails', return_value=[]):
+            with patch('glin.config._get_git_author_pattern', return_value='git@example.com'):
+                emails = get_tracked_emails()
+                assert emails == ["git@example.com"]
+
+    def test_empty_when_no_config(self, monkeypatch):
+        """Should return empty list when no configuration is found."""
+        monkeypatch.delenv("GLIN_TRACK_EMAILS", raising=False)
+        
+        with patch('glin.config._get_config_file_emails', return_value=[]):
+            with patch('glin.config._get_git_author_pattern', return_value=None):
+                emails = get_tracked_emails()
+                assert emails == []
+
+    def test_env_variable_whitespace_handling(self, monkeypatch):
+        """Environment variable should handle whitespace correctly."""
+        monkeypatch.setenv("GLIN_TRACK_EMAILS", " email1@example.com , email2@example.com , ")
+        emails = get_tracked_emails()
+        assert emails == ["email1@example.com", "email2@example.com"]
+
+
+class TestParseEmailsFromToml:
+    def test_parse_simple_array(self):
+        """Should parse simple email array from TOML."""
+        content = 'track_emails = ["user1@example.com", "user2@example.com"]'
+        emails = _parse_emails_from_toml(content)
+        assert emails == ["user1@example.com", "user2@example.com"]
+
+    def test_parse_with_whitespace(self):
+        """Should handle whitespace in TOML array."""
+        content = 'track_emails = [ "user1@example.com" , "user2@example.com" ]'
+        emails = _parse_emails_from_toml(content)
+        assert emails == ["user1@example.com", "user2@example.com"]
+
+    def test_parse_single_quotes(self):
+        """Should handle single quotes in TOML array."""
+        content = "track_emails = ['user1@example.com', 'user2@example.com']"
+        emails = _parse_emails_from_toml(content)
+        assert emails == ["user1@example.com", "user2@example.com"]
+
+    def test_parse_mixed_quotes(self):
+        """Should handle mixed quotes in TOML array."""
+        content = '''track_emails = ["user1@example.com", 'user2@example.com']'''
+        emails = _parse_emails_from_toml(content)
+        assert emails == ["user1@example.com", "user2@example.com"]
+
+    def test_parse_multiline_toml(self):
+        """Should find track_emails in multiline TOML content."""
+        content = """
+# Glin Configuration
+[section]
+other_setting = "value"
+
+track_emails = ["user@example.com"]
+
+[another_section]
+more_settings = true
+"""
+        emails = _parse_emails_from_toml(content)
+        assert emails == ["user@example.com"]
+
+    def test_parse_empty_array(self):
+        """Should handle empty array."""
+        content = 'track_emails = []'
+        emails = _parse_emails_from_toml(content)
+        assert emails == []
+
+    def test_parse_no_track_emails(self):
+        """Should return empty list when track_emails not found."""
+        content = 'other_setting = ["not", "emails"]'
+        emails = _parse_emails_from_toml(content)
+        assert emails == []
+
+
+class TestConfigFileEmails:
+    def test_reads_from_current_directory(self):
+        """Should read config from current directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "glin.toml"
+            config_path.write_text('track_emails = ["test@example.com"]')
+            
+            with patch('pathlib.Path.cwd', return_value=Path(tmpdir)):
+                emails = _get_config_file_emails()
+                assert emails == ["test@example.com"]
+
+    def test_reads_from_home_config(self):
+        """Should read config from ~/.config/glin/glin.toml."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / ".config" / "glin"
+            config_dir.mkdir(parents=True)
+            config_path = config_dir / "glin.toml"
+            config_path.write_text('track_emails = ["home@example.com"]')
+            
+            with patch('pathlib.Path.cwd', return_value=Path("/nonexistent")):
+                with patch('pathlib.Path.home', return_value=Path(tmpdir)):
+                    emails = _get_config_file_emails()
+                    assert emails == ["home@example.com"]
+
+    def test_handles_malformed_config(self):
+        """Should handle malformed config files gracefully."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "glin.toml"
+            config_path.write_text('invalid toml content [[[')
+            
+            with patch('pathlib.Path.cwd', return_value=Path(tmpdir)):
+                emails = _get_config_file_emails()
+                assert emails == []
+
+
+class TestSetTrackedEmailsEnv:
+    def test_sets_environment_variable(self, monkeypatch):
+        """Should set GLIN_TRACK_EMAILS environment variable."""
+        emails = ["test1@example.com", "test2@example.com"]
+        set_tracked_emails_env(emails)
+        
+        assert os.environ["GLIN_TRACK_EMAILS"] == "test1@example.com,test2@example.com"
+
+    def test_handles_empty_list(self):
+        """Should handle empty email list."""
+        set_tracked_emails_env([])
+        assert os.environ["GLIN_TRACK_EMAILS"] == ""
+
+
+class TestCreateConfigFile:
+    def test_creates_config_file(self):
+        """Should create config file with correct content."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "test_glin.toml"
+            emails = ["user1@example.com", "user2@example.com"]
+            
+            result_path = create_config_file(emails, config_path)
+            
+            assert result_path == config_path
+            assert config_path.exists()
+            
+            content = config_path.read_text()
+            assert 'track_emails = ["user1@example.com", "user2@example.com"]' in content
+            assert "# Glin Configuration" in content
+
+    def test_creates_default_path(self):
+        """Should create config file at default path when none specified."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('pathlib.Path.cwd', return_value=Path(tmpdir)):
+                emails = ["test@example.com"]
+                result_path = create_config_file(emails)
+                
+                expected_path = Path(tmpdir) / "glin.toml"
+                assert result_path == expected_path
+                assert expected_path.exists()
+
+    def test_creates_parent_directories(self):
+        """Should create parent directories if they don't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "nested" / "dir" / "glin.toml"
+            emails = ["test@example.com"]
+            
+            result_path = create_config_file(emails, config_path)
+            
+            assert result_path == config_path
+            assert config_path.exists()
+            assert config_path.parent.exists()
+
+
+class TestGitAuthorPattern:
+    def test_prefers_email_over_name(self):
+        """Should prefer git user.email over user.name."""
+        with patch('subprocess.run') as mock_run:
+            # First call (email) succeeds
+            mock_run.return_value.stdout = "user@example.com\n"
+            
+            result = _get_git_author_pattern()
+            assert result == "user@example.com"
+            
+            # Should only call git config for email, not name
+            mock_run.assert_called_once_with(
+                ["git", "config", "--get", "user.email"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+    def test_falls_back_to_name(self):
+        """Should fall back to git user.name when email fails."""
+        with patch('subprocess.run') as mock_run:
+            def side_effect(cmd, **kwargs):
+                if "user.email" in cmd:
+                    raise subprocess.CalledProcessError(1, cmd)
+                else:  # user.name
+                    mock_result = Mock()
+                    mock_result.stdout = "John Doe\n"
+                    return mock_result
+            
+            mock_run.side_effect = side_effect
+            
+            result = _get_git_author_pattern()
+            assert result == "John Doe"
+
+    def test_returns_none_when_both_fail(self):
+        """Should return None when both email and name fail."""
+        with patch('subprocess.run') as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(1, ["git"])
+            
+            result = _get_git_author_pattern()
+            assert result is None


### PR DESCRIPTION
- Add configuration system supporting multiple email addresses
- Support environment variable GLIN_TRACK_EMAILS (comma-separated)
- Support glin.toml configuration file with track_emails array
- Maintain backward compatibility with git user.email/user.name
- Add MCP tools for configuration management
- Update git log commands to support multiple --author filters
- Add comprehensive test coverage for new functionality
- Update documentation with configuration examples