### PR TITLE
Added: tool to initialize location to store output from MCP server

### DIFF
--- a/glin/mcp_app.py
+++ b/glin/mcp_app.py
@@ -87,6 +87,7 @@ from . import (
     git_tools as _git_tools,  # noqa: F401
     markdown_tools as _markdown_tools,  # noqa: F401
     prompts as _prompts,  # noqa: F401
+    scaffold_tools as _scaffold_tools,  # noqa: F401  # register workspace scaffold tool
     worklog_generator as _worklog_generator,  # noqa: F401  # register rich worklog tool
 )
 

--- a/glin/scaffold_tools.py
+++ b/glin/scaffold_tools.py
@@ -1,0 +1,163 @@
+import os
+from pathlib import Path
+from typing import TypedDict
+
+from .mcp_app import mcp
+from .storage.db import get_db_status, init_db
+
+
+class InitGlinSuccess(TypedDict):
+    ok: bool
+    dir: str
+    created: bool
+    worklog_path: str
+    db_path: str
+    toml_path: str
+    schema_version: int | None
+    message: str
+
+
+class InitGlinError(TypedDict):
+    error: str
+    dir: str
+    missing: list[str] | None
+
+
+def _write_toml(toml_path: Path, *, db_path: Path, markdown_path: Path) -> None:
+    """Write a minimal glin.toml with db_path and markdown_path configured.
+
+    We intentionally do not overwrite an existing file in the scaffold path; the caller
+    should only invoke this when creating a fresh workspace.
+    """
+    toml_path.parent.mkdir(parents=True, exist_ok=True)
+    content = (
+        "# Glin Configuration\n"
+        "# Managed by init_glin tool. You can edit values as needed.\n"
+        f'db_path = "{str(db_path)}"\n'
+        f'markdown_path = "{str(markdown_path)}"\n'
+        "# Optionally, set tracked emails (highest priority remains GLIN_TRACK_EMAILS env var):\n"
+        "# track_emails = [\n"
+        '#   "user1@example.com",\n'
+        '#   "user2@example.com",\n'
+        "# ]\n"
+    )
+    toml_path.write_text(content, encoding="utf-8")
+
+
+def _ensure_file(path: Path, *, initial_text: str | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text(initial_text or "", encoding="utf-8")
+
+
+@mcp.tool(
+    name="init_glin",
+    description=(
+        "Initialize a directory to hold WORKLOG.md, SQLite DB, and glin.toml. "
+        "If the directory exists and already contains those files, returns a helpful message. "
+        "If the directory exists but is missing any of the files, returns an error. "
+        "If the directory does not exist, creates it and scaffolds required files."
+    ),
+)
+async def init_glin(path: str) -> InitGlinSuccess | InitGlinError:
+    """Scaffold a Glin workspace directory.
+
+    Args:
+        path: Target directory path (absolute, or relative to current working directory). May include '~'.
+
+    Returns:
+        Success dict with created flag and file paths, or an error dict when pre-existing
+        directory is missing required files.
+    """
+    try:
+        if not path or not str(path).strip():
+            return InitGlinError(
+                error="path is required and cannot be empty",
+                dir=str(Path.cwd()),
+                missing=None,
+            )
+
+        base = Path(os.path.expanduser(path))
+        if not base.is_absolute():
+            base = Path.cwd() / base
+
+        worklog_path = base / "WORKLOG.md"
+        db_path = base / "db.sqlite3"
+        # Compute XDG config path for glin.toml
+        xdg_toml_path = Path.home() / ".config" / "glin" / "glin.toml"
+
+        if base.exists():
+            missing: list[str] = []
+            if not worklog_path.exists():
+                missing.append("WORKLOG.md")
+            if not db_path.exists():
+                missing.append("db.sqlite3")
+
+            if missing:
+                return InitGlinError(
+                    error=(
+                        "Directory exists but is not initialized. Missing: " + ", ".join(missing)
+                    ),
+                    dir=str(base),
+                    missing=missing,
+                )
+
+            # Already initialized — return status without modifying files
+            schema_version: int | None
+            try:
+                status = get_db_status(str(db_path))
+                schema_version = int(status.get("schema_version", 0))
+            except Exception:
+                schema_version = None
+
+            return InitGlinSuccess(
+                ok=True,
+                dir=str(base),
+                created=False,
+                worklog_path=str(worklog_path),
+                db_path=str(db_path),
+                toml_path=str(xdg_toml_path),
+                schema_version=schema_version,
+                message="Workspace already initialized.",
+            )
+
+        # Create directory and scaffold files
+        base.mkdir(parents=True, exist_ok=True)
+
+        # Create WORKLOG.md with a simple intro comment
+        _ensure_file(
+            worklog_path,
+            initial_text=(
+                "# Worklog\n\n"
+                "# This file is managed by Glin tools. You can append entries using MCP.\n\n"
+            ),
+        )
+
+        # Initialize the SQLite DB at the chosen path (creates file + schema)
+        init_db(str(db_path))
+
+        # Create glin.toml in XDG config path pointing to these files
+        _write_toml(xdg_toml_path, db_path=db_path, markdown_path=worklog_path)
+
+        # Gather DB schema version
+        try:
+            status = get_db_status(str(db_path))
+            schema_version2 = int(status.get("schema_version", 0))
+        except Exception:
+            schema_version2 = None
+
+        return InitGlinSuccess(
+            ok=True,
+            dir=str(base),
+            created=True,
+            worklog_path=str(worklog_path),
+            db_path=str(db_path),
+            toml_path=str(xdg_toml_path),
+            schema_version=schema_version2,
+            message="Workspace created and initialized.",
+        )
+
+    except Exception as e:
+        return InitGlinError(
+            error=f"Failed to scaffold workspace: {e}", dir=str(path), missing=None
+        )

--- a/tests/test_scaffold_tools.py
+++ b/tests/test_scaffold_tools.py
@@ -1,0 +1,164 @@
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from glin.scaffold_tools import init_glin
+
+
+def read_text(p: Path) -> str:
+    return p.read_text(encoding="utf-8").replace("\r\n", "\n").replace("\r", "\n")
+
+
+def test_rejects_empty_path(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    for payload in ("", "   ", "\n\n"):
+        res = asyncio.run(init_glin.fn(payload))
+        assert "error" in res
+        assert "path is required" in res["error"]
+        assert Path(res["dir"]) == tmp_path
+        assert res["missing"] is None
+
+
+def test_creates_new_workspace(monkeypatch, tmp_path: Path) -> None:
+    # Isolate XDG config to tmp_path
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    # Target path that does not exist yet
+    base = tmp_path / "ws"
+    worklog = base / "WORKLOG.md"
+    db = base / "db.sqlite3"
+    xdg_toml = tmp_path / ".config" / "glin" / "glin.toml"
+
+    # Mock DB init and status
+    calls: dict[str, Any] = {"init_db": 0, "status": 0}
+
+    def fake_init_db(path: str | None = None) -> int:
+        calls["init_db"] += 1
+        # create the file the way real init would ensure
+        Path(path or db).touch()
+        return 2
+
+    def fake_get_db_status(path: str | None = None) -> dict[str, Any]:
+        calls["status"] += 1
+        return {"schema_version": 2, "ok": True}
+
+    monkeypatch.setattr("glin.scaffold_tools.init_db", fake_init_db)
+    monkeypatch.setattr("glin.scaffold_tools.get_db_status", fake_get_db_status)
+
+    res = asyncio.run(init_glin.fn(str(base)))
+
+    assert res["ok"] is True
+    assert res["created"] is True
+    assert Path(res["dir"]) == base
+    assert Path(res["worklog_path"]) == worklog
+    assert Path(res["db_path"]) == db
+    assert Path(res["toml_path"]) == xdg_toml
+    assert res["schema_version"] == 2
+    assert "Workspace created and initialized" in res["message"]
+
+    # Files should exist and contain expected basics
+    assert worklog.exists()
+    wl = read_text(worklog)
+    assert wl.startswith("# Worklog\n\n")
+
+    assert xdg_toml.exists()
+    toml_text = read_text(xdg_toml)
+    assert f'db_path = "{str(db)}"' in toml_text
+    assert f'markdown_path = "{str(worklog)}"' in toml_text
+
+    # DB helpers used
+    assert calls["init_db"] == 1
+    assert calls["status"] >= 1
+
+
+def test_existing_dir_missing_files_returns_error(monkeypatch, tmp_path: Path) -> None:
+    # Isolate XDG config to tmp_path
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    base = tmp_path / "ws2"
+    base.mkdir()
+    # Create only WORKLOG.md so db is missing
+    (base / "WORKLOG.md").write_text("# Worklog\n", encoding="utf-8")
+
+    res = asyncio.run(init_glin.fn(str(base)))
+
+    assert "error" in res
+    assert res["dir"] == str(base)
+    assert res["missing"] == ["db.sqlite3"]
+    assert res["error"].startswith("Directory exists but is not initialized.")
+
+
+def test_already_initialized_reports_status(monkeypatch, tmp_path: Path) -> None:
+    # Isolate XDG config to tmp_path
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    base = tmp_path / "ws3"
+    worklog = base / "WORKLOG.md"
+    db = base / "db.sqlite3"
+    base.mkdir()
+    worklog.write_text("# Worklog\n", encoding="utf-8")
+    db.touch()
+
+    # get_db_status returns string version; should be coerced to int
+    def fake_get_db_status(path: str | None = None) -> dict[str, Any]:
+        return {"schema_version": "3", "ok": True}
+
+    init_called = {"count": 0}
+
+    def fake_init_db(path: str | None = None) -> int:
+        init_called["count"] += 1
+        return 3
+
+    monkeypatch.setattr("glin.scaffold_tools.get_db_status", fake_get_db_status)
+    monkeypatch.setattr("glin.scaffold_tools.init_db", fake_init_db)
+
+    res = asyncio.run(init_glin.fn(str(base)))
+
+    assert res["ok"] is True
+    assert res["created"] is False
+    assert res["schema_version"] == 3
+    assert "Workspace already initialized" in res["message"]
+    # Should not call init_db when already initialized
+    assert init_called["count"] == 0
+
+
+def test_already_initialized_when_status_raises_sets_none(monkeypatch, tmp_path: Path) -> None:
+    # Isolate XDG config to tmp_path
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    base = tmp_path / "ws4"
+    worklog = base / "WORKLOG.md"
+    db = base / "db.sqlite3"
+    base.mkdir()
+    worklog.write_text("# Worklog\n", encoding="utf-8")
+    db.touch()
+
+    def boom(path: str | None = None) -> dict[str, Any]:  # type: ignore[override]
+        raise RuntimeError("oops")
+
+    monkeypatch.setattr("glin.scaffold_tools.get_db_status", boom)
+
+    res = asyncio.run(init_glin.fn(str(base)))
+
+    assert res["ok"] is True
+    assert res["created"] is False
+    assert res["schema_version"] is None
+
+
+def test_relative_path_is_resolved_against_cwd(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    # Isolate XDG config to tmp_path
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    rel = Path("rel_dir")
+
+    # Mock DB functions to avoid real work
+    monkeypatch.setattr("glin.scaffold_tools.init_db", lambda p=None: 1)
+    monkeypatch.setattr(
+        "glin.scaffold_tools.get_db_status", lambda p=None: {"schema_version": 1, "ok": True}
+    )
+
+    res = asyncio.run(init_glin.fn(str(rel)))
+
+    assert Path(res["dir"]) == tmp_path / rel
+    assert Path(res["worklog_path"]).exists()
+    assert Path(res["toml_path"]).exists()


### PR DESCRIPTION
### Summary

This pull request enhances path configuration for the application, enabling support for `db_path` and `markdown_path` keys in the `glin.toml` configuration file. The changes include:

- Functions `get_markdown_path` and `get_db_path` for resolving paths based on TOML configuration, environment variables, and defaults.
- Updated path resolution logic to prioritize `glin.toml` keys over default paths.
- Enhanced Markdown tools with support for configurable file paths and priorities.
- Lightweight `_parse_string_from_toml` utility for streamlined TOML parsing.
- Improved error handling for missing or invalid TOML configurations.