### PR TITLE
Added: script entry point for seev in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ dependencies = [
     "fastmcp>=2.12.4",
 ]
 
+[project.scripts]
+seev = "seev.mcp_app:run"
+
 [dependency-groups]
 dev = [
     "ruff>=0.13.2",


### PR DESCRIPTION
This pull request introduces a script entry point for the `seev` application in the `pyproject.toml` file. The `seev` script is now mapped to the `seev.mcp_app:run` function under the `[project.scripts]` section. 

No breaking changes are introduced.