### PR TITLE
Updated: setup script URL and rename for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Seev turns your real work—commits, PRs, and AI conversations—into a clean da
 Copy this into your terminal to set up Seev and a local workspace:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bcosynot/seev/main/seev-init.sh | bash -s
+/bin/bash -c "$(curl -fsSL https://bcosynot.github.io/seev/init.sh)"
 ```
 
 Then restart your MCP client so it can load the Seev server.

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -24,7 +24,7 @@ Recommended: use the install script. It prepares a workspace folder, a WORKLOG.m
 
 ```bash
 # Create ~/seev-workspace with sensible defaults
-curl -fsSL https://raw.githubusercontent.com/bcosynot/seev/main/seev-init.sh | bash -s
+/bin/bash -c "$(curl -fsSL https://bcosynot.github.io/seev/init.sh)"
 ```
 
 - Creates the target dir if missing

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Copy these into your terminal:
 
 #### 1. Setup the MCP and workspace
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bcosynot/seev/main/seev-init.sh | bash -s
+/bin/bash -c "$(curl -fsSL https://bcosynot.github.io/seev/init.sh)"
 ```
 
 #### 2. Add a worklog entry

--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# seev-init.sh — Your one-minute Seev setup
+# init.sh — Your one-minute Seev setup
 #
 # What you get
 # - A ready-to-use folder that holds your personal Seev data:
@@ -14,7 +14,7 @@
 # - Customize later — you can edit the config or use env vars without re-running the script
 #
 # Quick start
-#   ./seev-init.sh [options] <target_dir>
+#   ./init.sh [options] <target_dir>
 #   If you omit <target_dir> or options, we’ll ask a few quick questions.
 #   Press Enter to accept defaults — you can tweak things any time.
 #
@@ -30,9 +30,9 @@
 #
 # Examples
 #   Minimal (accept prompts and defaults):
-#     ./seev-init.sh ~/seev-data
+#     ./init.sh ~/seev-data
 #   Pre-configure emails and repos (no prompts):
-#     ./seev-init.sh -y -e "me@ex.com" -r "owner/repo,~/code/that-repo" ~/seev-data
+#     ./init.sh -y -e "me@ex.com" -r "owner/repo,~/code/that-repo" ~/seev-data
 #
 # Tips
 # - You can override settings at runtime via env vars (great for experiments):


### PR DESCRIPTION
### Summary

This pull request updates the initialization script URL for improved reliability by replacing the raw GitHub link with a GitHub Pages URL. It also renames `seev-init.sh` to `init.sh` for consistent and clear usage across documentation and examples.

### Changes

- Replaced raw GitHub URL with GitHub Pages link in documentation.
- Renamed the script file from `seev-init.sh` to `init.sh`.
- Updated references in documentation, examples, and script comments.
  
### Checklist

- [ ] All documentation updated.
- [ ] All tests pass with the changes applied.